### PR TITLE
Implement swipe-based group activity MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Flutter/Dart
+**/.DS_Store
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+coverage/
+android/
+ios/
+web/
+windows/
+linux/
+macos/
+*.iml
+.idea/
+.vscode/
+*.log
+*.lock
+*.mmap

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    - avoid_print
+    - prefer_const_constructors
+    - prefer_const_literals_to_create_immutables
+    - prefer_final_fields
+    - always_declare_return_types

--- a/assets/data/events.json
+++ b/assets/data/events.json
@@ -1,0 +1,64 @@
+[
+  {
+    "id": "movie-1",
+    "category": "movies",
+    "title": "Midnight in Paris",
+    "description": "A charming romantic comedy set in the streets of Paris.",
+    "imageUrl": "https://image.tmdb.org/t/p/w500/placeholder_midnight_paris.jpg",
+    "priceLevel": 2,
+    "metadata": {"runtimeMinutes": 94, "tmdbId": 59436}
+  },
+  {
+    "id": "movie-2",
+    "category": "movies",
+    "title": "Into the Spider-Verse",
+    "description": "An award-winning animated adventure across the Spider-Verse.",
+    "imageUrl": "https://image.tmdb.org/t/p/w500/placeholder_spiderverse.jpg",
+    "priceLevel": 3,
+    "metadata": {"runtimeMinutes": 117, "tmdbId": 324857}
+  },
+  {
+    "id": "place-1",
+    "category": "places",
+    "title": "Sunset Rooftop Lounge",
+    "description": "Cocktails with skyline views and live DJ sets.",
+    "imageUrl": "https://example.com/images/rooftop.jpg",
+    "location": {
+      "latitude": 40.7128,
+      "longitude": -74.006,
+      "address": "120 Market St, New York, NY"
+    },
+    "priceLevel": 4,
+    "metadata": {"googlePlaceId": "abc123"}
+  },
+  {
+    "id": "place-2",
+    "category": "places",
+    "title": "Artisan Coffee Crawl",
+    "description": "Self-guided tour of the city's best espresso bars.",
+    "imageUrl": "https://example.com/images/coffee.jpg",
+    "location": {
+      "latitude": 34.0522,
+      "longitude": -118.2437,
+      "address": "Downtown Los Angeles, CA"
+    },
+    "priceLevel": 2,
+    "metadata": {"googlePlaceId": "def456"}
+  },
+  {
+    "id": "game-1",
+    "category": "videogames",
+    "title": "Overcooked! All You Can Eat",
+    "description": "Chaotic couch co-op cooking fun for up to four players.",
+    "imageUrl": "https://images.igdb.com/igdb/image/upload/t_cover_big/co1p7b.jpg",
+    "metadata": {"igdbId": 18760, "platforms": ["Switch", "PS5", "Xbox"]}
+  },
+  {
+    "id": "game-2",
+    "category": "videogames",
+    "title": "Stardew Valley",
+    "description": "Relaxed farming simulator with multiplayer support.",
+    "imageUrl": "https://images.igdb.com/igdb/image/upload/t_cover_big/co1r5f.jpg",
+    "metadata": {"igdbId": 1020, "platforms": ["PC", "Switch", "Mobile"]}
+  }
+]

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2024-06-05
+- Scaffolded Flutter project structure with Riverpod architecture and linting.
+- Added mock event repository, models, and assets spanning movies, places, and videogames.
+- Implemented onboarding, category selection, swipe deck, and match summary experiences.
+- Integrated MapLibre previews for place events and simulated group member preferences.
+- Added unit tests for match calculation logic and provider observer for diagnostics.
+- Documented roadmap progress in `progress.md`.

--- a/changelog.md
+++ b/changelog.md
@@ -7,3 +7,9 @@
 - Integrated MapLibre previews for place events and simulated group member preferences.
 - Added unit tests for match calculation logic and provider observer for diagnostics.
 - Documented roadmap progress in `progress.md`.
+
+## 2024-06-06
+- Introduced Riverpod-driven advanced filters for price, movie runtime, and videogame platforms with swipe deck UI controls.
+- Applied filter-aware querying in the mock event repository and summarised active filters in the swipe experience.
+- Authored a PostgreSQL-focused ER diagram in `docs/database_schema.md` to guide future persistence work.
+- Updated documentation (`readme.md`, `progress.md`) to highlight filtering enhancements and database planning.

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,0 +1,151 @@
+# Database Schema Diagram
+
+The diagram below captures the relational structure that supports collaborative swiping, advanced filtering, and match tracking. It is designed for PostgreSQL and keeps source-specific metadata in dedicated tables so that integrations (TMDB, Google Places, IGDB) can evolve independently.
+
+```mermaid
+erDiagram
+    USERS ||--o{ GROUP_MEMBERS : participates
+    GROUPS ||--o{ GROUP_MEMBERS : has
+    GROUPS ||--o{ GROUP_CATEGORY_PREFERENCES : selects
+    GROUPS ||--o{ GROUP_FILTER_PROFILES : configures
+    GROUP_FILTER_PROFILES ||--o{ GROUP_FILTER_PLATFORMS : allows
+    GROUPS ||--o{ GROUP_MATCHES : produces
+    GROUP_MATCHES ||--o{ MATCH_DECISIONS : summarises
+
+    EVENTS ||--o{ EVENT_LOCATIONS : located_at
+    EVENTS ||--o{ EVENT_PLATFORMS : supports
+    EVENTS ||--o{ MOVIE_DETAILS : movie_meta
+    EVENTS ||--o{ GAME_DETAILS : game_meta
+    EVENTS ||--o{ EVENT_SOURCES : sourced_from
+    EVENTS ||--o{ SWIPE_DECISIONS : receives
+
+    USERS {
+        uuid id PK
+        text display_name
+        text email
+        timestamptz created_at
+    }
+
+    GROUPS {
+        uuid id PK
+        text name
+        integer match_threshold
+        timestamptz created_at
+    }
+
+    GROUP_MEMBERS {
+        uuid id PK
+        uuid group_id FK
+        uuid user_id FK
+        boolean is_local
+        text role
+        timestamptz joined_at
+    }
+
+    GROUP_CATEGORY_PREFERENCES {
+        uuid id PK
+        uuid group_id FK
+        text category
+        timestamptz created_at
+    }
+
+    GROUP_FILTER_PROFILES {
+        uuid id PK
+        uuid group_id FK
+        integer max_price_level
+        integer max_runtime_minutes
+        numeric max_distance_km
+        timestamptz created_at
+    }
+
+    GROUP_FILTER_PLATFORMS {
+        uuid id PK
+        uuid filter_profile_id FK
+        text platform
+    }
+
+    EVENTS {
+        uuid id PK
+        text category
+        text title
+        text description
+        text image_url
+        integer price_level
+        jsonb metadata
+        timestamptz available_from
+    }
+
+    EVENT_LOCATIONS {
+        uuid id PK
+        uuid event_id FK
+        numeric latitude
+        numeric longitude
+        text address
+        text city
+        text country
+    }
+
+    EVENT_PLATFORMS {
+        uuid id PK
+        uuid event_id FK
+        text platform
+    }
+
+    MOVIE_DETAILS {
+        uuid event_id PK FK
+        integer runtime_minutes
+        integer tmdb_id
+        text certification
+    }
+
+    GAME_DETAILS {
+        uuid event_id PK FK
+        integer igdb_id
+        text genre
+        text age_rating
+    }
+
+    EVENT_SOURCES {
+        uuid id PK
+        uuid event_id FK
+        text provider
+        text external_id
+        timestamptz synced_at
+    }
+
+    SWIPE_DECISIONS {
+        uuid id PK
+        uuid event_id FK
+        uuid group_member_id FK
+        text decision
+        text reason
+        timestamptz decided_at
+    }
+
+    GROUP_MATCHES {
+        uuid id PK
+        uuid group_id FK
+        uuid event_id FK
+        text status
+        integer yes_votes
+        integer threshold
+        timestamptz created_at
+    }
+
+    MATCH_DECISIONS {
+        uuid id PK
+        uuid match_id FK
+        uuid group_member_id FK
+        text decision
+        timestamptz updated_at
+    }
+```
+
+## Design Notes
+
+- **Advanced filtering** lives in `GROUP_FILTER_PROFILES`, which stores ceiling values for price, runtime, and distance. Platform-specific filters use the `GROUP_FILTER_PLATFORMS` join table to keep the schema flexible as new console or streaming options emerge.
+- **Event metadata** is separated by content type. Movie-specific attributes (runtime, certification, TMDB identifiers) sit in `MOVIE_DETAILS`, whereas videogame enrichments (IGDB identifiers, genres, age ratings) live in `GAME_DETAILS`. Both tables share the event primary key, enabling efficient joins only when the data is relevant.
+- **Traceability** is provided by the `EVENT_SOURCES` and `SWIPE_DECISIONS` tables, ensuring that downstream analytics can inspect how preferences were formed and when matches were confirmed or reconsidered.
+- **Match lifecycle** uses `GROUP_MATCHES` and `MATCH_DECISIONS` so that partial approvals and later reversals can be recorded without losing the original swipe history.
+
+This schema keeps the domain extensible for future persistence work, while mirroring the advanced filtering capabilities introduced in the current UI.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'src/app/app.dart';
+import 'src/core/logging/provider_logger.dart';
+
+void main() {
+  runApp(
+    ProviderScope(
+      observers: const [ProviderLogger()],
+      child: const GroupSwipeApp(),
+    ),
+  );
+}

--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../features/onboarding/presentation/onboarding_flow.dart';
+
+class GroupSwipeApp extends StatelessWidget {
+  const GroupSwipeApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF6750A4)),
+      textTheme: GoogleFonts.interTextTheme(),
+      useMaterial3: true,
+    );
+
+    return MaterialApp(
+      title: 'Group Swipe',
+      debugShowCheckedModeBanner: false,
+      theme: theme,
+      home: const OnboardingFlow(),
+    );
+  }
+}

--- a/lib/src/app/app_state.dart
+++ b/lib/src/app/app_state.dart
@@ -1,0 +1,63 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/categories/domain/category.dart';
+import '../features/onboarding/domain/group_models.dart';
+
+enum AppStage { onboardingGroup, categorySelection, swipe, matches }
+
+class AppState extends Equatable {
+  const AppState({
+    this.stage = AppStage.onboardingGroup,
+    this.settings,
+    this.pendingCategories = const {},
+  });
+
+  final AppStage stage;
+  final GroupSettings? settings;
+  final Set<Category> pendingCategories;
+
+  AppState copyWith({
+    AppStage? stage,
+    GroupSettings? settings,
+    Set<Category>? pendingCategories,
+  }) {
+    return AppState(
+      stage: stage ?? this.stage,
+      settings: settings ?? this.settings,
+      pendingCategories: pendingCategories ?? this.pendingCategories,
+    );
+  }
+
+  @override
+  List<Object?> get props => [stage, settings, pendingCategories];
+}
+
+class AppFlowController extends StateNotifier<AppState> {
+  AppFlowController() : super(const AppState());
+
+  void saveGroupSettings(GroupSettings settings) {
+    state = state.copyWith(settings: settings, stage: AppStage.categorySelection);
+  }
+
+  void updateCategorySelection(Set<Category> categories) {
+    final currentSettings = state.settings;
+    if (currentSettings == null) {
+      return;
+    }
+    final newSettings = currentSettings.copyWith(selectedCategories: categories);
+    state = state.copyWith(settings: newSettings, stage: AppStage.swipe);
+  }
+
+  void showMatches() {
+    state = state.copyWith(stage: AppStage.matches);
+  }
+
+  void resetToCategories() {
+    state = state.copyWith(stage: AppStage.categorySelection);
+  }
+}
+
+final appFlowControllerProvider = StateNotifierProvider<AppFlowController, AppState>((ref) {
+  return AppFlowController();
+});

--- a/lib/src/core/logging/provider_logger.dart
+++ b/lib/src/core/logging/provider_logger.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Observes provider lifecycle events to aid debugging and analytics.
+class ProviderLogger extends ProviderObserver {
+  const ProviderLogger();
+
+  @override
+  void didAddProvider(ProviderBase<dynamic> provider, Object? value, ProviderContainer container) {
+    super.didAddProvider(provider, value, container);
+  }
+
+  @override
+  void didUpdateProvider(ProviderBase<dynamic> provider, Object? previousValue, Object? newValue, ProviderContainer container) {
+    super.didUpdateProvider(provider, previousValue, newValue, container);
+  }
+
+  @override
+  void didDisposeProvider(ProviderBase<dynamic> provider, ProviderContainer container) {
+    super.didDisposeProvider(provider, container);
+  }
+}

--- a/lib/src/features/categories/domain/category.dart
+++ b/lib/src/features/categories/domain/category.dart
@@ -1,0 +1,18 @@
+enum Category {
+  movies,
+  places,
+  videogames,
+}
+
+extension CategoryLabel on Category {
+  String get label {
+    switch (this) {
+      case Category.movies:
+        return 'Movies';
+      case Category.places:
+        return 'Places';
+      case Category.videogames:
+        return 'Videogames';
+    }
+  }
+}

--- a/lib/src/features/categories/presentation/category_selection_page.dart
+++ b/lib/src/features/categories/presentation/category_selection_page.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../domain/category.dart';
+
+class CategorySelectionPage extends ConsumerStatefulWidget {
+  const CategorySelectionPage({super.key});
+
+  @override
+  ConsumerState<CategorySelectionPage> createState() => _CategorySelectionPageState();
+}
+
+class _CategorySelectionPageState extends ConsumerState<CategorySelectionPage> {
+  late Set<Category> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = ref.read(appFlowControllerProvider).settings;
+    _selected = settings?.selectedCategories ?? Category.values.toSet();
+  }
+
+  void _toggle(Category category, bool value) {
+    setState(() {
+      if (value) {
+        _selected = {..._selected, category};
+      } else {
+        final updated = {..._selected}..remove(category);
+        if (updated.isEmpty) {
+          return;
+        }
+        _selected = updated;
+      }
+    });
+  }
+
+  void _continue() {
+    ref.read(appFlowControllerProvider.notifier).updateCategorySelection(_selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick categories'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Which types of plans do you want to explore?',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 24),
+            ...Category.values.map(
+              (category) => SwitchListTile(
+                value: _selected.contains(category),
+                onChanged: (value) => _toggle(category, value),
+                title: Text(category.label),
+              ),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _selected.isEmpty ? null : _continue,
+                child: const Text('Start swiping'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/events/application/event_filters_controller.dart
+++ b/lib/src/features/events/application/event_filters_controller.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../domain/event_filters.dart';
+
+class EventFiltersController extends StateNotifier<EventFilters> {
+  EventFiltersController() : super(const EventFilters());
+
+  void update(EventFilters filters) {
+    state = filters;
+  }
+
+  void reset() {
+    state = const EventFilters();
+  }
+}
+
+final eventFiltersProvider = StateNotifierProvider<EventFiltersController, EventFilters>((ref) {
+  return EventFiltersController();
+});

--- a/lib/src/features/events/data/event_repository_provider.dart
+++ b/lib/src/features/events/data/event_repository_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'mock_event_repository.dart';
+import '../domain/event_repository.dart';
+
+final eventRepositoryProvider = Provider<EventRepository>((ref) {
+  return const MockEventRepository();
+});

--- a/lib/src/features/events/data/mock_event_repository.dart
+++ b/lib/src/features/events/data/mock_event_repository.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../../categories/domain/category.dart';
+import '../domain/event.dart';
+import '../domain/event_repository.dart';
+import '../presentation/event_mapper.dart';
+
+class MockEventRepository implements EventRepository {
+  const MockEventRepository();
+
+  @override
+  Future<List<Event>> fetchEvents({required Set<Category> categories}) async {
+    final raw = await rootBundle.loadString('assets/data/events.json');
+    final parsed = jsonDecode(raw) as List<dynamic>;
+    final events = parsed
+        .map((dynamic item) => mapEventFromJson(item as Map<String, dynamic>))
+        .where((event) => categories.contains(event.category))
+        .toList();
+    events.shuffle();
+    return events;
+  }
+}

--- a/lib/src/features/events/data/mock_event_repository.dart
+++ b/lib/src/features/events/data/mock_event_repository.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart' show rootBundle;
 
 import '../../categories/domain/category.dart';
 import '../domain/event.dart';
+import '../domain/event_filters.dart';
 import '../domain/event_repository.dart';
 import '../presentation/event_mapper.dart';
 
@@ -11,14 +12,52 @@ class MockEventRepository implements EventRepository {
   const MockEventRepository();
 
   @override
-  Future<List<Event>> fetchEvents({required Set<Category> categories}) async {
+  Future<List<Event>> fetchEvents({
+    required Set<Category> categories,
+    EventFilters filters = const EventFilters(),
+  }) async {
     final raw = await rootBundle.loadString('assets/data/events.json');
     final parsed = jsonDecode(raw) as List<dynamic>;
     final events = parsed
         .map((dynamic item) => mapEventFromJson(item as Map<String, dynamic>))
         .where((event) => categories.contains(event.category))
+        .where((event) => _matchesFilters(event, filters))
         .toList();
     events.shuffle();
     return events;
+  }
+
+  bool _matchesFilters(Event event, EventFilters filters) {
+    if (filters.maxPriceLevel != null && event.priceLevel != null) {
+      if (event.priceLevel! > filters.maxPriceLevel!) {
+        return false;
+      }
+    }
+
+    switch (event.category) {
+      case Category.movies:
+        if (filters.maxRuntimeMinutes != null) {
+          final runtime = event.metadata['runtimeMinutes'];
+          if (runtime is num && runtime > filters.maxRuntimeMinutes!) {
+            return false;
+          }
+        }
+        break;
+      case Category.videogames:
+        if (filters.preferredPlatforms.isNotEmpty) {
+          final platforms = event.metadata['platforms'];
+          final platformList =
+              platforms is List ? platforms.map((platform) => platform.toString()).toList() : <String>[];
+          final matches = platformList.any(filters.preferredPlatforms.contains);
+          if (!matches) {
+            return false;
+          }
+        }
+        break;
+      case Category.places:
+        break;
+    }
+
+    return true;
   }
 }

--- a/lib/src/features/events/domain/event.dart
+++ b/lib/src/features/events/domain/event.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+
+import '../../categories/domain/category.dart';
+
+class Event extends Equatable {
+  const Event({
+    required this.id,
+    required this.category,
+    required this.title,
+    required this.description,
+    this.imageUrl,
+    this.location,
+    this.priceLevel,
+    this.metadata = const {},
+  });
+
+  final String id;
+  final Category category;
+  final String title;
+  final String description;
+  final String? imageUrl;
+  final EventLocation? location;
+  final int? priceLevel;
+  final Map<String, Object?> metadata;
+
+  @override
+  List<Object?> get props => [id, category, title, description, imageUrl, location, priceLevel, metadata];
+}
+
+class EventLocation extends Equatable {
+  const EventLocation({
+    required this.latitude,
+    required this.longitude,
+    this.address,
+  });
+
+  final double latitude;
+  final double longitude;
+  final String? address;
+
+  @override
+  List<Object?> get props => [latitude, longitude, address];
+}

--- a/lib/src/features/events/domain/event_filters.dart
+++ b/lib/src/features/events/domain/event_filters.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+
+class EventFilters extends Equatable {
+  const EventFilters({
+    this.maxPriceLevel,
+    this.maxRuntimeMinutes,
+    this.preferredPlatforms = const <String>{},
+  });
+
+  final int? maxPriceLevel;
+  final int? maxRuntimeMinutes;
+  final Set<String> preferredPlatforms;
+
+  bool get hasActiveFilters =>
+      maxPriceLevel != null || maxRuntimeMinutes != null || preferredPlatforms.isNotEmpty;
+
+  EventFilters copyWith({
+    int? maxPriceLevel,
+    bool removeMaxPriceLevel = false,
+    int? maxRuntimeMinutes,
+    bool removeMaxRuntimeMinutes = false,
+    Set<String>? preferredPlatforms,
+  }) {
+    return EventFilters(
+      maxPriceLevel: removeMaxPriceLevel ? null : (maxPriceLevel ?? this.maxPriceLevel),
+      maxRuntimeMinutes:
+          removeMaxRuntimeMinutes ? null : (maxRuntimeMinutes ?? this.maxRuntimeMinutes),
+      preferredPlatforms: preferredPlatforms ?? this.preferredPlatforms,
+    );
+  }
+
+  EventFilters reset() => const EventFilters();
+
+  @override
+  List<Object?> get props => [maxPriceLevel, maxRuntimeMinutes, preferredPlatforms];
+}
+
+class EventFilterOptions {
+  const EventFilterOptions();
+
+  static const List<int> priceLevels = [1, 2, 3, 4];
+  static const List<int> runtimeMinutes = [60, 90, 120, 150];
+  static const List<String> gamePlatforms = ['PC', 'Switch', 'PS5', 'Xbox', 'Mobile'];
+}

--- a/lib/src/features/events/domain/event_repository.dart
+++ b/lib/src/features/events/domain/event_repository.dart
@@ -1,6 +1,10 @@
 import '../../categories/domain/category.dart';
 import 'event.dart';
+import 'event_filters.dart';
 
 abstract class EventRepository {
-  Future<List<Event>> fetchEvents({required Set<Category> categories});
+  Future<List<Event>> fetchEvents({
+    required Set<Category> categories,
+    EventFilters filters = const EventFilters(),
+  });
 }

--- a/lib/src/features/events/domain/event_repository.dart
+++ b/lib/src/features/events/domain/event_repository.dart
@@ -1,0 +1,6 @@
+import '../../categories/domain/category.dart';
+import 'event.dart';
+
+abstract class EventRepository {
+  Future<List<Event>> fetchEvents({required Set<Category> categories});
+}

--- a/lib/src/features/events/presentation/event_card.dart
+++ b/lib/src/features/events/presentation/event_card.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/mapbox_gl.dart';
+
+import '../domain/event.dart';
+
+class EventCard extends StatelessWidget {
+  const EventCard({super.key, required this.event});
+
+  final Event event;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (event.imageUrl != null)
+            SizedBox(
+              height: 220,
+              width: double.infinity,
+              child: Image.network(
+                event.imageUrl!,
+                fit: BoxFit.cover,
+                errorBuilder: (context, _, __) => Container(
+                  color: Colors.grey.shade300,
+                  alignment: Alignment.center,
+                  child: const Icon(Icons.image_not_supported),
+                ),
+              ),
+            )
+          else
+            Container(
+              height: 220,
+              width: double.infinity,
+              color: Colors.grey.shade200,
+              alignment: Alignment.center,
+              child: const Icon(Icons.image),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  event.title,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                Text(event.description),
+                if (event.location != null) ...[
+                  const SizedBox(height: 16),
+                  _MapPreview(location: event.location!),
+                ],
+                if (event.priceLevel != null) ...[
+                  const SizedBox(height: 8),
+                  Text('Price level: ${'\$' * (event.priceLevel ?? 0)}'),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapPreview extends StatelessWidget {
+  const _MapPreview({required this.location});
+
+  final EventLocation location;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: 160,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: MaplibreMap(
+              compassEnabled: false,
+              myLocationEnabled: false,
+              styleString: 'https://demotiles.maplibre.org/style.json',
+              initialCameraPosition: CameraPosition(
+                target: LatLng(location.latitude, location.longitude),
+                zoom: 13,
+              ),
+              onMapCreated: (controller) {
+                controller.addSymbol(
+                  SymbolOptions(
+                    geometry: LatLng(location.latitude, location.longitude),
+                    iconImage: 'marker-15',
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        if (location.address != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            location.address!,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/src/features/events/presentation/event_filters_sheet.dart
+++ b/lib/src/features/events/presentation/event_filters_sheet.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../application/event_filters_controller.dart';
+import '../domain/event_filters.dart';
+
+class EventFiltersSheet extends ConsumerStatefulWidget {
+  const EventFiltersSheet({super.key});
+
+  @override
+  ConsumerState<EventFiltersSheet> createState() => _EventFiltersSheetState();
+}
+
+class _EventFiltersSheetState extends ConsumerState<EventFiltersSheet> {
+  late EventFilters _draft;
+
+  @override
+  void initState() {
+    super.initState();
+    _draft = ref.read(eventFiltersProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final padding = MediaQuery.of(context).viewInsets;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(bottom: padding.bottom),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Refine recommendations',
+                        style: theme.textTheme.titleMedium,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.refresh),
+                      tooltip: 'Reset filters',
+                      onPressed: () {
+                        setState(() {
+                          _draft = const EventFilters();
+                        });
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _Section(
+                  title: 'Price level',
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('Any'),
+                        selected: _draft.maxPriceLevel == null,
+                        onSelected: (_) {
+                          setState(() {
+                            _draft = _draft.copyWith(removeMaxPriceLevel: true);
+                          });
+                        },
+                      ),
+                      ...EventFilterOptions.priceLevels.map(
+                        (level) => ChoiceChip(
+                          label: Text('\$' * level),
+                          selected: _draft.maxPriceLevel == level,
+                          onSelected: (_) {
+                            setState(() {
+                              _draft = _draft.copyWith(maxPriceLevel: level);
+                            });
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _Section(
+                  title: 'Max runtime (movies)',
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('Any'),
+                        selected: _draft.maxRuntimeMinutes == null,
+                        onSelected: (_) {
+                          setState(() {
+                            _draft = _draft.copyWith(removeMaxRuntimeMinutes: true);
+                          });
+                        },
+                      ),
+                      ...EventFilterOptions.runtimeMinutes.map(
+                        (minutes) => ChoiceChip(
+                          label: Text('≤ ${minutes}m'),
+                          selected: _draft.maxRuntimeMinutes == minutes,
+                          onSelected: (_) {
+                            setState(() {
+                              _draft = _draft.copyWith(maxRuntimeMinutes: minutes);
+                            });
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _Section(
+                  title: 'Supported platforms (videogames)',
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ...EventFilterOptions.gamePlatforms.map(
+                        (platform) {
+                          final selected = _draft.preferredPlatforms.contains(platform);
+                          return FilterChip(
+                            label: Text(platform),
+                            selected: selected,
+                            onSelected: (_) {
+                              setState(() {
+                                final updated = Set<String>.from(_draft.preferredPlatforms);
+                                if (selected) {
+                                  updated.remove(platform);
+                                } else {
+                                  updated.add(platform);
+                                }
+                                _draft = _draft.copyWith(preferredPlatforms: updated);
+                              });
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () {
+                          setState(() {
+                            _draft = const EventFilters();
+                          });
+                          ref.read(eventFiltersProvider.notifier).reset();
+                          Navigator.of(context).pop();
+                        },
+                        child: const Text('Clear filters'),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: () {
+                          ref.read(eventFiltersProvider.notifier).update(_draft);
+                          Navigator.of(context).pop();
+                        },
+                        child: const Text('Apply'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/src/features/events/presentation/event_mapper.dart
+++ b/lib/src/features/events/presentation/event_mapper.dart
@@ -1,0 +1,23 @@
+import '../../categories/domain/category.dart';
+import '../domain/event.dart';
+
+Event mapEventFromJson(Map<String, dynamic> json) {
+  final category = Category.values.firstWhere((value) => value.name == json['category']);
+  final locationJson = json['location'] as Map<String, dynamic>?;
+  return Event(
+    id: json['id'] as String,
+    category: category,
+    title: json['title'] as String,
+    description: json['description'] as String,
+    imageUrl: json['imageUrl'] as String?,
+    location: locationJson == null
+        ? null
+        : EventLocation(
+            latitude: (locationJson['latitude'] as num).toDouble(),
+            longitude: (locationJson['longitude'] as num).toDouble(),
+            address: locationJson['address'] as String?,
+          ),
+    priceLevel: (json['priceLevel'] as num?)?.toInt(),
+    metadata: (json['metadata'] as Map<String, dynamic>?) ?? const {},
+  );
+}

--- a/lib/src/features/matches/application/match_calculator.dart
+++ b/lib/src/features/matches/application/match_calculator.dart
@@ -1,0 +1,55 @@
+import '../../onboarding/domain/group_models.dart';
+import '../../swipe/domain/swipe_models.dart';
+import '../domain/match_models.dart';
+
+class MatchCalculator {
+  const MatchCalculator();
+
+  List<MatchResult> calculate({
+    required GroupSettings settings,
+    required Map<String, List<SwipeDecision>> decisions,
+  }) {
+    final events = <String, List<SwipeDecision>>{};
+    for (final entry in decisions.entries) {
+      for (final decision in entry.value) {
+        events.putIfAbsent(decision.event.id, () => []).add(decision);
+      }
+    }
+
+    final results = <MatchResult>[];
+    for (final eventDecisions in events.values) {
+      final yesVotes = eventDecisions.where((decision) => decision.type == SwipeDecisionType.yes).toList();
+      final noVotes = eventDecisions.where((decision) => decision.type == SwipeDecisionType.no).toList();
+      final yesMembers = settings.members.where((member) => yesVotes.any((decision) => decision.memberId == member.id)).toList();
+      final noMembers = settings.members
+          .where((member) => noVotes.any((decision) => decision.memberId == member.id))
+          .map(
+            (member) => NoVoter(
+              member: member,
+              reason: noVotes.firstWhere((decision) => decision.memberId == member.id).reason,
+            ),
+          )
+          .toList();
+      final event = eventDecisions.first.event;
+      final yesCount = yesVotes.length;
+      final matchType = yesCount == settings.members.length
+          ? MatchType.full
+          : yesCount >= settings.matchThreshold
+              ? MatchType.partial
+              : null;
+      if (matchType != null) {
+        results.add(
+          MatchResult(
+            event: event,
+            type: matchType,
+            yesVoters: yesMembers,
+            noVoters: noMembers,
+          ),
+        );
+      }
+    }
+
+    results.sort((a, b) => a.type.index.compareTo(b.type.index));
+    return results;
+  }
+}

--- a/lib/src/features/matches/application/match_provider.dart
+++ b/lib/src/features/matches/application/match_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../swipe/application/swipe_deck_controller.dart';
+import '../domain/match_models.dart';
+import 'match_calculator.dart';
+
+final matchResultsProvider = Provider<List<MatchResult>>((ref) {
+  final settings = ref.watch(appFlowControllerProvider).settings;
+  final swipeState = ref.watch(swipeDeckControllerProvider);
+  if (settings == null) {
+    return const [];
+  }
+  final calculator = const MatchCalculator();
+  return calculator.calculate(settings: settings, decisions: swipeState.decisions);
+});
+
+final fullMatchesProvider = Provider<List<MatchResult>>((ref) {
+  return ref.watch(matchResultsProvider).where((match) => match.type == MatchType.full).toList();
+});
+
+final partialMatchesProvider = Provider<List<MatchResult>>((ref) {
+  return ref.watch(matchResultsProvider).where((match) => match.type == MatchType.partial).toList();
+});

--- a/lib/src/features/matches/domain/match_models.dart
+++ b/lib/src/features/matches/domain/match_models.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+import '../../events/domain/event.dart';
+import '../../onboarding/domain/group_models.dart';
+import '../../swipe/domain/swipe_models.dart';
+
+enum MatchType { full, partial }
+
+class MatchResult extends Equatable {
+  const MatchResult({
+    required this.event,
+    required this.type,
+    required this.yesVoters,
+    required this.noVoters,
+  });
+
+  final Event event;
+  final MatchType type;
+  final List<GroupMember> yesVoters;
+  final List<NoVoter> noVoters;
+
+  @override
+  List<Object?> get props => [event, type, yesVoters, noVoters];
+}
+
+class NoVoter extends Equatable {
+  const NoVoter({
+    required this.member,
+    required this.reason,
+  });
+
+  final GroupMember member;
+  final DecisionReason? reason;
+
+  @override
+  List<Object?> get props => [member, reason];
+}

--- a/lib/src/features/matches/presentation/match_summary_page.dart
+++ b/lib/src/features/matches/presentation/match_summary_page.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../onboarding/domain/group_models.dart';
+import '../../swipe/application/swipe_deck_controller.dart';
+import '../application/match_provider.dart';
+import '../domain/match_models.dart';
+
+class MatchSummaryPage extends ConsumerWidget {
+  const MatchSummaryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fullMatches = ref.watch(fullMatchesProvider);
+    final partialMatches = ref.watch(partialMatchesProvider);
+    final settings = ref.watch(appFlowControllerProvider).settings;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Your matches'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.category),
+            onPressed: () => ref.read(appFlowControllerProvider.notifier).resetToCategories(),
+            tooltip: 'Adjust categories',
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (fullMatches.isEmpty)
+              const _SectionHeader(title: 'No full matches yet')
+            else ...[
+              const _SectionHeader(title: 'Ready to go'),
+              ...fullMatches.map((match) => _MatchCard(match: match)),
+            ],
+            const SizedBox(height: 24),
+            if (partialMatches.isEmpty)
+              const _SectionHeader(title: 'No partial matches yet')
+            else ...[
+              const _SectionHeader(title: 'Need confirmations'),
+              ...partialMatches.map(
+                (match) => _PartialMatchCard(match: match, settings: settings),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge,
+      ),
+    );
+  }
+}
+
+class _MatchCard extends StatelessWidget {
+  const _MatchCard({required this.match});
+
+  final MatchResult match;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              match.event.title,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(match.event.description),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: match.yesVoters
+                  .map(
+                    (member) => Chip(
+                      avatar: const Icon(Icons.check, size: 16),
+                      label: Text(member.displayName),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PartialMatchCard extends ConsumerWidget {
+  const _PartialMatchCard({required this.match, required this.settings});
+
+  final MatchResult match;
+  final GroupSettings? settings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    GroupMember? localMember;
+    final resolvedSettings = settings;
+    if (resolvedSettings != null && resolvedSettings.members.isNotEmpty) {
+      try {
+        localMember = resolvedSettings.members.firstWhere((member) => member.isLocal);
+      } catch (_) {
+        localMember = resolvedSettings.members.first;
+      }
+    }
+    final controller = ref.read(swipeDeckControllerProvider.notifier);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              match.event.title,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(match.event.description),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: match.yesVoters
+                  .map(
+                    (member) => Chip(
+                      avatar: const Icon(Icons.check, size: 16),
+                      label: Text(member.displayName),
+                    ),
+                  )
+                  .toList(),
+            ),
+            const SizedBox(height: 12),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: match.noVoters
+                  .map(
+                    (noVoter) => ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      leading: const Icon(Icons.close),
+                      title: Text(noVoter.member.displayName),
+                      subtitle: Text(noVoter.reason?.label ?? 'No reason provided'),
+                      trailing: noVoter.member.id == localMember?.id
+                          ? TextButton(
+                              onPressed: () => controller.reconsiderDecision(noVoter.member.id, match.event),
+                              child: const Text('Change to yes'),
+                            )
+                          : null,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/domain/group_models.dart
+++ b/lib/src/features/onboarding/domain/group_models.dart
@@ -1,0 +1,73 @@
+import 'package:equatable/equatable.dart';
+
+import '../../categories/domain/category.dart';
+
+enum DecisionThresholdType { unanimous, custom }
+
+enum DecisionReason {
+  expensive,
+  tooFar,
+  notInterested,
+  other,
+}
+
+extension DecisionReasonLabel on DecisionReason {
+  String get label {
+    switch (this) {
+      case DecisionReason.expensive:
+        return 'Expensive';
+      case DecisionReason.tooFar:
+        return 'Too far';
+      case DecisionReason.notInterested:
+        return 'Not interested';
+      case DecisionReason.other:
+        return 'Other';
+    }
+  }
+}
+
+class GroupMember extends Equatable {
+  const GroupMember({
+    required this.id,
+    required this.displayName,
+    this.isLocal = false,
+  });
+
+  final String id;
+  final String displayName;
+  final bool isLocal;
+
+  @override
+  List<Object?> get props => [id, displayName, isLocal];
+}
+
+class GroupSettings extends Equatable {
+  const GroupSettings({
+    required this.groupName,
+    required this.members,
+    required this.matchThreshold,
+    required this.selectedCategories,
+  });
+
+  final String groupName;
+  final List<GroupMember> members;
+  final int matchThreshold;
+  final Set<Category> selectedCategories;
+
+  GroupSettings copyWith({
+    String? groupName,
+    List<GroupMember>? members,
+    int? matchThreshold,
+    Set<Category>? selectedCategories,
+  }) {
+    return GroupSettings(
+      groupName: groupName ?? this.groupName,
+      members: members ?? this.members,
+      matchThreshold: matchThreshold ?? this.matchThreshold,
+      selectedCategories: selectedCategories ?? this.selectedCategories,
+    );
+  }
+
+  @override
+  List<Object?> get props => [groupName, members, matchThreshold, selectedCategories];
+}

--- a/lib/src/features/onboarding/presentation/group_setup_page.dart
+++ b/lib/src/features/onboarding/presentation/group_setup_page.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../categories/domain/category.dart';
+import '../domain/group_models.dart';
+
+class GroupSetupPage extends ConsumerStatefulWidget {
+  const GroupSetupPage({super.key});
+
+  @override
+  ConsumerState<GroupSetupPage> createState() => _GroupSetupPageState();
+}
+
+class _GroupSetupPageState extends ConsumerState<GroupSetupPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _groupNameController = TextEditingController();
+  int _memberCount = 2;
+  int _threshold = 2;
+
+  @override
+  void dispose() {
+    _groupNameController.dispose();
+    super.dispose();
+  }
+
+  void _handleContinue() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final members = List.generate(_memberCount, (index) {
+      final isLocal = index == 0;
+      return GroupMember(
+        id: 'member-${index + 1}',
+        displayName: isLocal ? 'You' : 'Member ${index + 1}',
+        isLocal: isLocal,
+      );
+    });
+    final settings = GroupSettings(
+      groupName: _groupNameController.text.trim(),
+      members: members,
+      matchThreshold: _threshold,
+      selectedCategories: Category.values.toSet(),
+    );
+    ref.read(appFlowControllerProvider.notifier).saveGroupSettings(settings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create your group'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Start by telling us about your crew.',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 24),
+                TextFormField(
+                  controller: _groupNameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Group name',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a group name';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    const Expanded(child: Text('How many people are swiping?')),
+                    DropdownButton<int>(
+                      value: _memberCount,
+                      items: List.generate(8, (index) => index + 2)
+                          .map(
+                            (count) => DropdownMenuItem<int>(
+                              value: count,
+                              child: Text('$count'),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: (value) {
+                        if (value == null) {
+                          return;
+                        }
+                        setState(() {
+                          _memberCount = value;
+                          _threshold = value == 2 ? 2 : value - 1;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'How many yes votes are needed for a plan?',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ),
+                    DropdownButton<int>(
+                      value: _threshold,
+                      items: List.generate(_memberCount - 1, (index) => index + 2)
+                          .map(
+                            (value) => DropdownMenuItem<int>(
+                              value: value,
+                              child: Text('$value'),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: _memberCount <= 2
+                          ? null
+                          : (value) {
+                              if (value == null) {
+                                return;
+                              }
+                              setState(() {
+                                _threshold = value;
+                              });
+                            },
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: _handleContinue,
+                    child: const Text('Continue'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/presentation/onboarding_flow.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_flow.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../categories/presentation/category_selection_page.dart';
+import '../../matches/presentation/match_summary_page.dart';
+import '../../swipe/presentation/swipe_experience_page.dart';
+import 'group_setup_page.dart';
+
+class OnboardingFlow extends ConsumerWidget {
+  const OnboardingFlow({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appState = ref.watch(appFlowControllerProvider);
+    switch (appState.stage) {
+      case AppStage.onboardingGroup:
+        return const GroupSetupPage();
+      case AppStage.categorySelection:
+        return const CategorySelectionPage();
+      case AppStage.swipe:
+        return const SwipeExperiencePage();
+      case AppStage.matches:
+        return const MatchSummaryPage();
+    }
+  }
+}

--- a/lib/src/features/swipe/application/group_preference_simulator.dart
+++ b/lib/src/features/swipe/application/group_preference_simulator.dart
@@ -1,0 +1,35 @@
+import '../../events/domain/event.dart';
+import '../../onboarding/domain/group_models.dart';
+import '../domain/swipe_models.dart';
+
+class GroupPreferenceSimulator {
+  const GroupPreferenceSimulator();
+
+  List<SwipeDecision> simulate(Event event, List<GroupMember> members) {
+    return members
+        .map(
+          (member) => _decisionForMember(event, member),
+        )
+        .toList();
+  }
+
+  SwipeDecision _decisionForMember(Event event, GroupMember member) {
+    final hash = event.id.hashCode + member.id.hashCode;
+    final isYes = hash % 3 != 0; // deterministic yet varied.
+    if (isYes) {
+      return SwipeDecision(
+        event: event,
+        memberId: member.id,
+        type: SwipeDecisionType.yes,
+      );
+    }
+    final reasons = DecisionReason.values;
+    final reasonIndex = hash.abs() % reasons.length;
+    return SwipeDecision(
+      event: event,
+      memberId: member.id,
+      type: SwipeDecisionType.no,
+      reason: reasons[reasonIndex],
+    );
+  }
+}

--- a/lib/src/features/swipe/application/swipe_deck_controller.dart
+++ b/lib/src/features/swipe/application/swipe_deck_controller.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/app_state.dart';
+import '../../events/application/event_filters_controller.dart';
 import '../../events/data/event_repository_provider.dart';
+import '../../events/domain/event_filters.dart';
 import '../../events/domain/event.dart';
 import '../../onboarding/domain/group_models.dart';
 import '../domain/swipe_models.dart';
@@ -13,6 +15,11 @@ class SwipeDeckController extends StateNotifier<SwipeDeckState> {
   SwipeDeckController(this.ref)
       : _simulator = const GroupPreferenceSimulator(),
         super(SwipeDeckState.loading()) {
+    ref.listen<EventFilters>(eventFiltersProvider, (previous, next) {
+      if (previous != next) {
+        refreshDeck();
+      }
+    }, fireImmediately: false);
     _initialise();
   }
 
@@ -35,7 +42,11 @@ class SwipeDeckController extends StateNotifier<SwipeDeckState> {
     }
     state = SwipeDeckState.loading();
     final repository = ref.read(eventRepositoryProvider);
-    final events = await repository.fetchEvents(categories: settings.selectedCategories);
+    final filters = ref.read(eventFiltersProvider);
+    final events = await repository.fetchEvents(
+      categories: settings.selectedCategories,
+      filters: filters,
+    );
     final baseDecisions = {
       for (final member in settings.members) member.id: <SwipeDecision>[],
     };

--- a/lib/src/features/swipe/application/swipe_deck_controller.dart
+++ b/lib/src/features/swipe/application/swipe_deck_controller.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../events/data/event_repository_provider.dart';
+import '../../events/domain/event.dart';
+import '../../onboarding/domain/group_models.dart';
+import '../domain/swipe_models.dart';
+import 'group_preference_simulator.dart';
+
+class SwipeDeckController extends StateNotifier<SwipeDeckState> {
+  SwipeDeckController(this.ref)
+      : _simulator = const GroupPreferenceSimulator(),
+        super(SwipeDeckState.loading()) {
+    _initialise();
+  }
+
+  final Ref ref;
+  final GroupPreferenceSimulator _simulator;
+  Completer<void>? _loadingCompleter;
+
+  Future<void> _initialise() async {
+    if (_loadingCompleter != null) {
+      return _loadingCompleter!.future;
+    }
+    final completer = Completer<void>();
+    _loadingCompleter = completer;
+    final settings = ref.read(appFlowControllerProvider).settings;
+    if (settings == null) {
+      state = SwipeDeckState.loading();
+      completer.complete();
+      _loadingCompleter = null;
+      return;
+    }
+    state = SwipeDeckState.loading();
+    final repository = ref.read(eventRepositoryProvider);
+    final events = await repository.fetchEvents(categories: settings.selectedCategories);
+    final baseDecisions = {
+      for (final member in settings.members) member.id: <SwipeDecision>[],
+    };
+    state = SwipeDeckState(events: events, index: 0, decisions: baseDecisions, isLoading: false);
+    completer.complete();
+    _loadingCompleter = null;
+  }
+
+  Future<void> refreshDeck() async {
+    await _initialise();
+  }
+
+  void recordLocalDecision({required SwipeDecisionType type, DecisionReason? reason}) {
+    final currentEvent = state.currentEvent;
+    if (currentEvent == null) {
+      ref.read(appFlowControllerProvider.notifier).showMatches();
+      return;
+    }
+    final settings = ref.read(appFlowControllerProvider).settings;
+    if (settings == null) {
+      return;
+    }
+    final localMember = settings.members.firstWhere((member) => member.isLocal);
+    final updatedDecisions = Map<String, List<SwipeDecision>>.from(state.decisions);
+    final localDecisions = List<SwipeDecision>.from(updatedDecisions[localMember.id] ?? []);
+    localDecisions.removeWhere((decision) => decision.event.id == currentEvent.id);
+    localDecisions.add(
+      SwipeDecision(
+        event: currentEvent,
+        memberId: localMember.id,
+        type: type,
+        reason: reason,
+      ),
+    );
+    updatedDecisions[localMember.id] = localDecisions;
+
+    final remoteMembers = settings.members.where((member) => !member.isLocal).toList();
+    for (final decision in _simulator.simulate(currentEvent, remoteMembers)) {
+      final remoteDecisions = List<SwipeDecision>.from(updatedDecisions[decision.memberId] ?? []);
+      remoteDecisions.removeWhere((item) => item.event.id == currentEvent.id);
+      remoteDecisions.add(decision);
+      updatedDecisions[decision.memberId] = remoteDecisions;
+    }
+
+    state = state.copyWith(decisions: updatedDecisions);
+    _advanceDeck();
+  }
+
+  void _advanceDeck() {
+    final nextIndex = state.index + 1;
+    if (nextIndex >= state.events.length) {
+      ref.read(appFlowControllerProvider.notifier).showMatches();
+    } else {
+      state = state.copyWith(index: nextIndex);
+    }
+  }
+
+  void reconsiderDecision(String memberId, Event event) {
+    final updatedDecisions = Map<String, List<SwipeDecision>>.from(state.decisions);
+    final memberDecisions = List<SwipeDecision>.from(updatedDecisions[memberId] ?? []);
+    final index = memberDecisions.indexWhere((decision) => decision.event.id == event.id);
+    if (index == -1) {
+      return;
+    }
+    final current = memberDecisions[index];
+    memberDecisions[index] = current.copyWith(type: SwipeDecisionType.yes, reason: null);
+    updatedDecisions[memberId] = memberDecisions;
+    state = state.copyWith(decisions: updatedDecisions);
+  }
+}
+
+final swipeDeckControllerProvider = StateNotifierProvider<SwipeDeckController, SwipeDeckState>((ref) {
+  return SwipeDeckController(ref);
+});

--- a/lib/src/features/swipe/domain/swipe_models.dart
+++ b/lib/src/features/swipe/domain/swipe_models.dart
@@ -1,0 +1,72 @@
+import 'package:equatable/equatable.dart';
+
+import '../../events/domain/event.dart';
+import '../../onboarding/domain/group_models.dart';
+
+enum SwipeDirection { left, right }
+
+enum SwipeDecisionType { yes, no }
+
+class SwipeDecision extends Equatable {
+  const SwipeDecision({
+    required this.event,
+    required this.memberId,
+    required this.type,
+    this.reason,
+  });
+
+  final Event event;
+  final String memberId;
+  final SwipeDecisionType type;
+  final DecisionReason? reason;
+
+  SwipeDecision copyWith({
+    SwipeDecisionType? type,
+    DecisionReason? reason,
+  }) {
+    return SwipeDecision(
+      event: event,
+      memberId: memberId,
+      type: type ?? this.type,
+      reason: reason ?? this.reason,
+    );
+  }
+
+  @override
+  List<Object?> get props => [event, memberId, type, reason];
+}
+
+class SwipeDeckState extends Equatable {
+  const SwipeDeckState({
+    required this.events,
+    required this.index,
+    required this.decisions,
+    this.isLoading = false,
+  });
+
+  factory SwipeDeckState.loading() => const SwipeDeckState(events: [], index: 0, decisions: {}, isLoading: true);
+
+  final List<Event> events;
+  final int index;
+  final Map<String, List<SwipeDecision>> decisions;
+  final bool isLoading;
+
+  Event? get currentEvent => index < events.length ? events[index] : null;
+
+  SwipeDeckState copyWith({
+    List<Event>? events,
+    int? index,
+    Map<String, List<SwipeDecision>>? decisions,
+    bool? isLoading,
+  }) {
+    return SwipeDeckState(
+      events: events ?? this.events,
+      index: index ?? this.index,
+      decisions: decisions ?? this.decisions,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+
+  @override
+  List<Object?> get props => [events, index, decisions, isLoading];
+}

--- a/lib/src/features/swipe/presentation/swipe_experience_page.dart
+++ b/lib/src/features/swipe/presentation/swipe_experience_page.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/app_state.dart';
+import '../../events/presentation/event_card.dart';
+import '../../onboarding/domain/group_models.dart';
+import '../application/swipe_deck_controller.dart';
+import '../domain/swipe_models.dart';
+
+class SwipeExperiencePage extends ConsumerWidget {
+  const SwipeExperiencePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final deckState = ref.watch(swipeDeckControllerProvider);
+    final controller = ref.read(swipeDeckControllerProvider.notifier);
+
+    if (deckState.isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final currentEvent = deckState.currentEvent;
+    if (currentEvent == null) {
+      return Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('You have reached the end of the deck!'),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () => ref.read(appFlowControllerProvider.notifier).showMatches(),
+                child: const Text('View matches'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Swipe plans'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: controller.refreshDeck,
+            tooltip: 'Refresh events',
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Expanded(
+                child: EventCard(event: currentEvent),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () => _selectReason(context, controller),
+                      icon: const Icon(Icons.close),
+                      label: const Text('Not now'),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: () => controller.recordLocalDecision(type: SwipeDecisionType.yes),
+                      icon: const Icon(Icons.favorite),
+                      label: const Text('Yes'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectReason(BuildContext context, SwipeDeckController controller) async {
+    final reason = await showModalBottomSheet<DecisionReason>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Why is this a no?',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              ...DecisionReason.values.map(
+                (reason) => ListTile(
+                  title: Text(reason.label),
+                  onTap: () => Navigator.of(context).pop(reason),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (reason != null) {
+      controller.recordLocalDecision(type: SwipeDecisionType.no, reason: reason);
+    }
+  }
+}

--- a/lib/src/features/swipe/presentation/swipe_experience_page.dart
+++ b/lib/src/features/swipe/presentation/swipe_experience_page.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/app_state.dart';
+import '../../events/application/event_filters_controller.dart';
+import '../../events/domain/event_filters.dart';
 import '../../events/presentation/event_card.dart';
+import '../../events/presentation/event_filters_sheet.dart';
 import '../../onboarding/domain/group_models.dart';
 import '../application/swipe_deck_controller.dart';
 import '../domain/swipe_models.dart';
@@ -13,6 +16,7 @@ class SwipeExperiencePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final deckState = ref.watch(swipeDeckControllerProvider);
+    final filters = ref.watch(eventFiltersProvider);
     final controller = ref.read(swipeDeckControllerProvider.notifier);
 
     if (deckState.isLoading) {
@@ -45,6 +49,11 @@ class SwipeExperiencePage extends ConsumerWidget {
         title: const Text('Swipe plans'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.filter_alt),
+            tooltip: 'Filters',
+            onPressed: () => _openFilters(context),
+          ),
+          IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: controller.refreshDeck,
             tooltip: 'Refresh events',
@@ -56,6 +65,10 @@ class SwipeExperiencePage extends ConsumerWidget {
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              if (filters.hasActiveFilters) ...[
+                _ActiveFiltersSummary(filters: filters),
+                const SizedBox(height: 16),
+              ],
               Expanded(
                 child: EventCard(event: currentEvent),
               ),
@@ -115,5 +128,55 @@ class SwipeExperiencePage extends ConsumerWidget {
     if (reason != null) {
       controller.recordLocalDecision(type: SwipeDecisionType.no, reason: reason);
     }
+  }
+
+  Future<void> _openFilters(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => const EventFiltersSheet(),
+    );
+  }
+}
+
+class _ActiveFiltersSummary extends StatelessWidget {
+  const _ActiveFiltersSummary({required this.filters});
+
+  final EventFilters filters;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chips = <Widget>[];
+    if (filters.maxPriceLevel != null) {
+      final priceLabel = '\$' * (filters.maxPriceLevel ?? 0);
+      chips.add(Chip(label: Text('≤ $priceLabel')));
+    }
+    if (filters.maxRuntimeMinutes != null) {
+      chips.add(Chip(label: Text('≤ ${filters.maxRuntimeMinutes}m movies')));
+    }
+    final sortedPlatforms = filters.preferredPlatforms.toList()..sort();
+    for (final platform in sortedPlatforms) {
+      chips.add(Chip(label: Text(platform)));
+    }
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Active filters',
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: chips,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,31 @@
+# Progress Tracker
+
+## Milestone 1: Foundations & Planning
+- [x] Defined high-level Flutter + Riverpod architecture and project structure.
+- [x] Identified third-party APIs (Google Places, TMDB, IGDB) and map stack (MapLibre).
+- [x] Established data models for users, groups, events, and swipes.
+- [x] Added repository scaffolding, lint rules, and placeholder assets for prototyping.
+
+## Milestone 2: Core Experience (MVP)
+- [x] Implemented onboarding flow for creating a group and configuring thresholds.
+- [x] Added category selection UI for Movies, Places, and Videogames.
+- [x] Built swipe deck experience with yes/no actions and rejection reasons.
+- [x] Captured "no" reasons with predefined options.
+- [x] Calculated matches with full and partial grouping logic.
+- [x] Created match summary views for full matches and partial re-evaluations.
+
+## Milestone 3: Data Integrations
+- [x] Normalized provider data into a unified event model.
+- [x] Added mock repository with Google Places / TMDB / IGDB placeholders and MapLibre preview support.
+- [ ] Implemented live API clients and caching layers.
+
+## Milestone 4: Collaboration & Re-evaluation
+- [x] Enabled users to revisit partial matches and convert "no" to "yes" decisions.
+- [ ] Added realtime notifications for new matches after re-evaluation.
+- [ ] Persisted decisions in a backend service.
+
+## Milestone 5: Enhancements & Polish
+- [ ] Added advanced filtering (price, distance, genre).
+- [x] Integrated Riverpod provider observer for logging.
+- [x] Added unit tests for match logic.
+- [ ] Implemented pagination and performance tuning.

--- a/progress.md
+++ b/progress.md
@@ -5,6 +5,7 @@
 - [x] Identified third-party APIs (Google Places, TMDB, IGDB) and map stack (MapLibre).
 - [x] Established data models for users, groups, events, and swipes.
 - [x] Added repository scaffolding, lint rules, and placeholder assets for prototyping.
+- [x] Drafted PostgreSQL ERD to guide future persistence work.
 
 ## Milestone 2: Core Experience (MVP)
 - [x] Implemented onboarding flow for creating a group and configuring thresholds.
@@ -25,7 +26,7 @@
 - [ ] Persisted decisions in a backend service.
 
 ## Milestone 5: Enhancements & Polish
-- [ ] Added advanced filtering (price, distance, genre).
+- [x] Added advanced filtering (price, runtime, platforms).
 - [x] Integrated Riverpod provider observer for logging.
 - [x] Added unit tests for match logic.
 - [ ] Implemented pagination and performance tuning.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,38 @@
+name: group_swipe
+description: Group-based activity discovery app with swipe matchmaking.
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.5.1
+  riverpod_annotation: ^2.3.3
+  hooks_riverpod: ^2.5.1
+  freezed_annotation: ^2.4.1
+  json_annotation: ^4.9.0
+  http: ^1.2.0
+  maplibre_gl: ^0.17.0
+  google_fonts: ^6.1.0
+  equatable: ^2.0.5
+
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.2
+  build_runner: ^2.4.10
+  freezed: ^2.4.7
+  json_serializable: ^6.7.1
+
+dependency_overrides:
+  analyzer: ^6.4.1
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/data/
+    - assets/images/

--- a/readme.md
+++ b/readme.md
@@ -10,11 +10,13 @@ The Group Activity Swipe App is a Flutter-based mobile application that helps fr
 - **Match curation**: Display separate lists for full matches (everyone said yes) and partial matches that need reconsideration by specific members.
 - **Map-powered places**: Preview location cards with MapLibre and ready-to-wire Google Places IDs.
 - **Simulated group consensus**: Deterministic simulator generates other members' votes so the full/partial match flows can be exercised end-to-end before the realtime backend is ready.
+- **Advanced filtering**: Configure maximum price, movie runtime ceilings, and preferred videogame platforms to tailor the swipe deck before the backend persists preferences.
 
 ## Architecture
 - **Presentation**: Material 3 UI split into feature directories (`onboarding`, `categories`, `swipe`, `matches`, `events`). Widgets consume Riverpod providers instead of stateful singletons.
 - **State management**: `appFlowController` coordinates navigation stages, `swipeDeckController` orchestrates event queues, and match providers compute derived results. A `ProviderLogger` observer is wired for future analytics.
 - **Data layer**: `MockEventRepository` hydrates cards from `assets/data/events.json` with normalized models. Replace with real API clients once credentials are available.
+- **Filtering**: A dedicated `EventFiltersController` drives Riverpod-powered filter state that is applied during repository fetches and summarised in the swipe UI.
 - **Domain models**: Equatable types (`GroupSettings`, `Event`, `SwipeDecision`, `MatchResult`) encapsulate business logic and power deterministic unit tests.
 - **Testing**: `test/match_calculator_test.dart` validates match thresholds and reason handling. Expand with widget/integration tests as APIs solidify.
 
@@ -37,6 +39,9 @@ The Group Activity Swipe App is a Flutter-based mobile application that helps fr
 2. Configure environment variables and API keys for Google Places, TMDB, and IGDB.
 3. Swap the mock repository with real API clients and wire persistence for swipe decisions.
 4. Follow the roadmap in [`roadmap.md`](./roadmap.md) to iterate towards a production-ready MVP.
+
+## Database Planning
+- Consult [`docs/database_schema.md`](./docs/database_schema.md) for the PostgreSQL-oriented entity relationship diagram that underpins persistence work and mirrors the advanced filtering model introduced in the prototype.
 
 ## Contributing
 - Follow the naming, formatting, and state management conventions described in [`flutter_dart_riverpod_mockito.md`](./flutter_dart_riverpod_mockito.md).

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,44 @@
+# Group Activity Swipe App
+
+## Overview
+The Group Activity Swipe App is a Flutter-based mobile application that helps friends decide what to do together. Inspired by the Tinder swipe interaction, each user can swipe right to accept or left to reject events drawn from multiple categories such as movies, places, and videogames. The system aggregates individual preferences to surface unanimous or partial matches so groups can quickly agree on plans.
+
+## Core Features
+- **Group-based decision making**: Require at least two members per group, support configurable partial match thresholds for larger groups, and let undecided users revisit their choices.
+- **Swipe interaction**: Present events in a card deck that users swipe right (yes) or left (no) while optionally supplying predefined rejection reasons (Expensive, Too far, Not interested, Other).
+- **Multi-category events**: Source activities from Google Places (via Places API + MapLibre for visualization), movies from TMDB, and videogames from IGDB, with a unified data model for consistent presentation.
+- **Match curation**: Display separate lists for full matches (everyone said yes) and partial matches that need reconsideration by specific members.
+- **Map-powered places**: Preview location cards with MapLibre and ready-to-wire Google Places IDs.
+- **Simulated group consensus**: Deterministic simulator generates other members' votes so the full/partial match flows can be exercised end-to-end before the realtime backend is ready.
+
+## Architecture
+- **Presentation**: Material 3 UI split into feature directories (`onboarding`, `categories`, `swipe`, `matches`, `events`). Widgets consume Riverpod providers instead of stateful singletons.
+- **State management**: `appFlowController` coordinates navigation stages, `swipeDeckController` orchestrates event queues, and match providers compute derived results. A `ProviderLogger` observer is wired for future analytics.
+- **Data layer**: `MockEventRepository` hydrates cards from `assets/data/events.json` with normalized models. Replace with real API clients once credentials are available.
+- **Domain models**: Equatable types (`GroupSettings`, `Event`, `SwipeDecision`, `MatchResult`) encapsulate business logic and power deterministic unit tests.
+- **Testing**: `test/match_calculator_test.dart` validates match thresholds and reason handling. Expand with widget/integration tests as APIs solidify.
+
+## Running locally
+1. Install Flutter 3.19+ and enable the desired platforms (`flutter config --enable-{ios,android,web}` as needed).
+2. Fetch dependencies and generate artifacts: `flutter pub get` and `dart run build_runner build -d`.
+3. Launch the app on a simulator/emulator: `flutter run`.
+4. Execute automated tests: `flutter test`.
+
+> **API Keys**: Provide `GOOGLE_PLACES_KEY`, `TMDB_KEY`, and `IGDB_CLIENT/SECRET` via `.env` or runtime configuration when implementing the live repositories.
+
+## Technical Approach
+- **Client**: Flutter application following the best practices outlined in [`flutter_dart_riverpod_mockito.md`](./flutter_dart_riverpod_mockito.md), using Riverpod for state management, reusable widgets, and comprehensive testing.
+- **Backend & Data**: API layer that aggregates content providers, normalizes payloads, caches responses, and manages user/group state. Consider Firebase, Supabase, or a custom backend for persistence and authentication.
+- **Mapping**: Integrate MapLibre for rendering place locations returned by the Google Places API and enabling location-aware filtering.
+- **Testing Strategy**: Unit tests for business logic (match thresholds, swipe handling), widget tests for UI flows, and integration tests that mock external APIs using Mockito-generated mocks.
+
+## Getting Started
+1. Review [`progress.md`](./progress.md) to understand what has been completed from the roadmap and what remains.
+2. Configure environment variables and API keys for Google Places, TMDB, and IGDB.
+3. Swap the mock repository with real API clients and wire persistence for swipe decisions.
+4. Follow the roadmap in [`roadmap.md`](./roadmap.md) to iterate towards a production-ready MVP.
+
+## Contributing
+- Follow the naming, formatting, and state management conventions described in [`flutter_dart_riverpod_mockito.md`](./flutter_dart_riverpod_mockito.md).
+- Document any architectural changes within `roadmap.md` to maintain a history of decisions and milestones.
+- Ensure new features include relevant tests and respect the modular structure for future category expansion.

--- a/roadmap.md
+++ b/roadmap.md
@@ -35,7 +35,7 @@ Build a group-based activity discovery application where users swipe through eve
 - Persist decisions and match states in backend storage (e.g., Firebase, Supabase, or custom backend).
 
 ### 5. Enhancements & Polish
-- Add filtering options (price range, distance, genre).
+- Add advanced filtering (price ceilings, runtime thresholds, platform preferences) and expand with distance-based rules once location data is available.
 - Implement analytics and logging through Riverpod provider observers.
 - Add testing layers: unit tests for match logic, widget tests for swipe interactions, integration tests for API clients.
 - Optimize performance with pagination, caching, and `const` widgets where applicable.
@@ -50,3 +50,4 @@ Build a group-based activity discovery application where users swipe through eve
 ## Change Log
 - **2024-06-05**: Initial roadmap drafted capturing milestones, guiding principles, and next steps.
 - **2024-06-05**: Scaffolded Flutter app with Riverpod architecture, mock data integrations, and end-to-end MVP flows (onboarding, swipe, matches).
+- **2024-06-06**: Added advanced client-side filtering controls and drafted the initial PostgreSQL ERD in preparation for persistence work.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,52 @@
+# Project Roadmap
+
+## Vision
+Build a group-based activity discovery application where users swipe through events from multiple content providers (places, movies, videogames) and surface full or partial matches based on group preferences.
+
+## Guiding Principles
+- Follow the best practices documented in `flutter_dart_riverpod_mockito.md` for architecture, naming, state management, and testing.
+- Prioritize modularity to support new content categories and additional providers in the future.
+- Ensure privacy and data security when handling group membership and preferences.
+
+## Milestones
+
+### 1. Foundations & Planning
+- Define high-level architecture (Flutter + Riverpod + backend services).
+- Identify required third-party APIs (Google Places, TMDB, IGDB) and authentication needs.
+- Decide data model for users, groups, events, and swipes.
+- Establish repository structure and tooling (formatting, linting, CI/CD).
+
+### 2. Core Experience (MVP)
+- Implement onboarding flow for creating/joining groups.
+- Build category selection UI allowing users to toggle Movies, Places, and Videogames.
+- Implement swipe deck experience for events, including left (no) and right (yes) gestures.
+- Capture "no" reasons from predefined list (Expensive, Too far, Not interested, Other).
+- Calculate matches based on group size rules (unanimous for 2, configurable threshold for larger groups).
+- Provide match list view highlighting full matches for the group and partial matches requiring reconsideration.
+
+### 3. Data Integrations
+- Integrate Google Places API to fetch and display place events, including map previews via MapLibre.
+- Integrate TMDB API for movies and IGDB API for videogames, with caching to limit API calls.
+- Normalize data from providers into unified event model.
+
+### 4. Collaboration & Re-evaluation
+- Allow users who said "no" on partial matches to review and update their decision.
+- Notify group members when new matches are achieved after re-evaluation.
+- Persist decisions and match states in backend storage (e.g., Firebase, Supabase, or custom backend).
+
+### 5. Enhancements & Polish
+- Add filtering options (price range, distance, genre).
+- Implement analytics and logging through Riverpod provider observers.
+- Add testing layers: unit tests for match logic, widget tests for swipe interactions, integration tests for API clients.
+- Optimize performance with pagination, caching, and `const` widgets where applicable.
+
+## Next Steps
+1. Finalize technical stack decision and draft architecture diagram.
+2. Scaffold Flutter project with Riverpod setup and linting rules.
+3. Prototype swipe deck UI using placeholder data.
+4. Implement backend/API wrappers with mocked data for testing.
+5. Iterate towards full MVP functionality before integrating live APIs.
+
+## Change Log
+- **2024-06-05**: Initial roadmap drafted capturing milestones, guiding principles, and next steps.
+- **2024-06-05**: Scaffolded Flutter app with Riverpod architecture, mock data integrations, and end-to-end MVP flows (onboarding, swipe, matches).

--- a/test/match_calculator_test.dart
+++ b/test/match_calculator_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:group_swipe/src/features/categories/domain/category.dart';
+import 'package:group_swipe/src/features/events/domain/event.dart';
+import 'package:group_swipe/src/features/matches/application/match_calculator.dart';
+import 'package:group_swipe/src/features/matches/domain/match_models.dart';
+import 'package:group_swipe/src/features/onboarding/domain/group_models.dart';
+import 'package:group_swipe/src/features/swipe/domain/swipe_models.dart';
+
+void main() {
+  group('MatchCalculator', () {
+    final calculator = const MatchCalculator();
+    final members = [
+      const GroupMember(id: 'member-1', displayName: 'A', isLocal: true),
+      const GroupMember(id: 'member-2', displayName: 'B'),
+      const GroupMember(id: 'member-3', displayName: 'C'),
+    ];
+    final settings = GroupSettings(
+      groupName: 'Crew',
+      members: members,
+      matchThreshold: 2,
+      selectedCategories: {Category.movies},
+    );
+    final event = Event(
+      id: 'event-1',
+      category: Category.movies,
+      title: 'Movie night',
+      description: 'Test movie',
+    );
+
+    test('creates full match when all vote yes', () {
+      final decisions = {
+        for (final member in members)
+          member.id: [
+            SwipeDecision(
+              event: event,
+              memberId: member.id,
+              type: SwipeDecisionType.yes,
+            ),
+          ],
+      };
+
+      final results = calculator.calculate(settings: settings, decisions: decisions);
+      expect(results, hasLength(1));
+      expect(results.first.type, MatchType.full);
+      expect(results.first.yesVoters, hasLength(3));
+    });
+
+    test('creates partial match when threshold met but not unanimous', () {
+      final decisions = {
+        members[0].id: [
+          SwipeDecision(
+            event: event,
+            memberId: members[0].id,
+            type: SwipeDecisionType.yes,
+          ),
+        ],
+        members[1].id: [
+          SwipeDecision(
+            event: event,
+            memberId: members[1].id,
+            type: SwipeDecisionType.yes,
+          ),
+        ],
+        members[2].id: [
+          SwipeDecision(
+            event: event,
+            memberId: members[2].id,
+            type: SwipeDecisionType.no,
+            reason: DecisionReason.notInterested,
+          ),
+        ],
+      };
+
+      final results = calculator.calculate(settings: settings, decisions: decisions);
+      expect(results, hasLength(1));
+      expect(results.first.type, MatchType.partial);
+      expect(results.first.noVoters.first.reason, DecisionReason.notInterested);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold a Flutter + Riverpod project structure with mock data sources and shared models
- implement onboarding, category selection, swipe deck, and match summary flows with MapLibre previews and simulated group votes
- document progress and changes via updated README, changelog, and progress tracker

## Testing
- not run (Dart/Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5896cd45c832098ef20eb9889584d